### PR TITLE
Fix unsatisfiable constraints libressl-dev and openssl-dev;

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # StrongSwan VPN + Alpine Linux
 #
 
-FROM alpine:edge
+FROM alpine:latest
 
 ENV STRONGSWAN_RELEASE https://download.strongswan.org/strongswan.tar.bz2
 


### PR DESCRIPTION
To prevent conflicts:

ERROR: unsatisfiable constraints:
  libressl-dev-2.7.4-r0:
    conflicts:
               openssl-dev-1.0.2o-r1[pc:libcrypto=2.7.4]
               openssl-dev-1.0.2o-r1[pc:libssl=2.7.4]
               openssl-dev-1.0.2o-r1[pc:openssl=2.7.4]
    satisfies: curl-dev-7.60.0-r1[libressl-dev]
               libssh2-dev-1.8.0-r3[pc:libcrypto]
               libssh2-dev-1.8.0-r3[pc:libssl]
  openssl-dev-1.0.2o-r1:
    conflicts:
               libressl-dev-2.7.4-r0[pc:libcrypto=1.0.2o]
               libressl-dev-2.7.4-r0[pc:libssl=1.0.2o]
               libressl-dev-2.7.4-r0[pc:openssl=1.0.2o]
    satisfies: world[openssl-dev]
               libssh2-dev-1.8.0-r3[pc:libcrypto]
               libssh2-dev-1.8.0-r3[pc:libssl]